### PR TITLE
AddBatch modal updates

### DIFF
--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/_components/AddAdmin.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/_components/AddAdmin.tsx
@@ -35,7 +35,7 @@ export const AddAdmin = ({ cohortAddress }: AddAdminProps) => {
 
       <input type="checkbox" id="add-admin-modal" className="modal-toggle" />
       <label htmlFor="add-admin-modal" className="modal cursor-pointer">
-        <label className="modal-box relative shadow shadow-primary">
+        <label className="modal-box relative border border-primary">
           {/* dummy input to capture event onclick on modal box */}
           <input className="h-0 w-0 absolute top-0 left-0" />
           <div className="font-bold mb-8 flex items-center gap-1">Add a new admin</div>

--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/AddBatch.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/AddBatch.tsx
@@ -68,7 +68,7 @@ export const AddBatch = ({ cohortAddress, isErc20, tokenDecimals }: AddbatchProp
 
       <input type="checkbox" id="add-batch-modal" className="modal-toggle" />
       <label htmlFor="add-batch-modal" className="modal cursor-pointer">
-        <label className="modal-box relative shadow shadow-primary">
+        <label className="modal-box relative border border-primary">
           <input className="h-0 w-0 absolute top-0 left-0" />
           <p className="font-bold mb-8 flex items-center gap-1 ">Add new builders</p>
           <label htmlFor="add-batch-modal" className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">


### PR DESCRIPTION
When viewing the AddBatch modal, the shadow was causing the top to blend into the background.  Updated it from shadow to border.

old:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/716be10d-7e07-4128-b233-ffb4c48c094d" />

new:
<img width="564" alt="image" src="https://github.com/user-attachments/assets/fa080f1f-a566-453e-b5cf-e1d01a226d30" />

