### PR TITLE
modal closure after sucessful transaction and leading period in ether input

### DIFF
--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/_components/FundCohort.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/_components/FundCohort.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { EtherInput } from "~~/components/scaffold-eth";
 import { useFunding } from "~~/hooks/useFunding";
 
@@ -16,7 +16,7 @@ export const FundCohort = ({ cohortAddress, tokenAddress, isErc20, tokenSymbol, 
   const [amount, setAmount] = useState<number>(0);
   const [isTransferLoading, setIsTransferLoading] = useState(false);
 
-  const { fund, isLoading, isMining, approve, allowance } = useFunding({
+  const { fund, isLoading, isMining, approve, allowance, isSuccess } = useFunding({
     cohortAddress,
     amount,
     tokenAddress,
@@ -36,6 +36,16 @@ export const FundCohort = ({ cohortAddress, tokenAddress, isErc20, tokenSymbol, 
     }
     setIsTransferLoading(false);
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      const modalCheckbox = document.getElementById("fund-cohort-modal") as HTMLInputElement;
+      if (modalCheckbox) {
+        modalCheckbox.checked = false;
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess]);
 
   return (
     <>

--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/ApproveWithdrawal.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/ApproveWithdrawal.tsx
@@ -1,18 +1,31 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useApproveWithdrawal } from "~~/hooks/useApproveWithdrawal";
 
 interface ApproveWithdrawalProps {
   requestId: number;
   cohortAddress: string;
   builderAddress: string;
+  onClose: () => void;
 }
 
-export const ApproveWithdrawal = ({ requestId, cohortAddress, builderAddress }: ApproveWithdrawalProps) => {
-  const { approveWithdrawal, isPending } = useApproveWithdrawal({
+export const ApproveWithdrawal = ({ requestId, cohortAddress, builderAddress, onClose }: ApproveWithdrawalProps) => {
+  const { approveWithdrawal, isPending, isSuccess } = useApproveWithdrawal({
     cohortAddress,
     builderAddress,
     requestId,
   });
+
+  useEffect(() => {
+    if (isSuccess) {
+      const modalCheckbox = document.getElementById("withdraw-events-modal") as HTMLInputElement;
+      if (modalCheckbox) {
+        modalCheckbox.checked = false;
+        onClose();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess]);
+
   return (
     <button onClick={approveWithdrawal} disabled={isPending} className="btn btn-sm rounded-md btn-primary">
       Approve

--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/CompleteWithdrawal.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/CompleteWithdrawal.tsx
@@ -1,16 +1,29 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useCompleteWithdrawal } from "~~/hooks/useCompleteWithdrawal";
 
 interface CompleteWithdrawalProps {
   requestId: number;
   cohortAddress: string;
+  onClose: () => void;
 }
 
-export const CompleteWithdrawal = ({ requestId, cohortAddress }: CompleteWithdrawalProps) => {
-  const { completeWithdrawal, isPending } = useCompleteWithdrawal({
+export const CompleteWithdrawal = ({ requestId, cohortAddress, onClose }: CompleteWithdrawalProps) => {
+  const { completeWithdrawal, isPending, isSuccess } = useCompleteWithdrawal({
     cohortAddress,
     requestId,
   });
+
+  useEffect(() => {
+    if (isSuccess) {
+      const modalCheckbox = document.getElementById("withdraw-events-modal") as HTMLInputElement;
+      if (modalCheckbox) {
+        modalCheckbox.checked = false;
+        onClose();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess]);
+
   return (
     <button onClick={completeWithdrawal} disabled={isPending} className="btn btn-sm rounded-md btn-primary">
       Complete

--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/EventsModal.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/EventsModal.tsx
@@ -145,17 +145,23 @@ export const EventsModal: React.FC<EventsModalProps> = ({
                               cohortAddress={cohortAddress}
                               builderAddress={event.args.builder}
                               requestId={event.args.requestId}
+                              onClose={onClose}
                             />
                             <RejectWithdrawal
                               cohortAddress={cohortAddress}
                               builderAddress={event.args.builder}
                               requestId={event.args.requestId}
+                              onClose={onClose}
                             />
                           </div>
                         )}
                         {address == event.args.builder && event.status === "Approved" && (
                           <div className="flex gap-2 mt-2">
-                            <CompleteWithdrawal cohortAddress={cohortAddress} requestId={event.args.requestId} />
+                            <CompleteWithdrawal
+                              cohortAddress={cohortAddress}
+                              requestId={event.args.requestId}
+                              onClose={onClose}
+                            />
                           </div>
                         )}
                         <hr className="my-8" />

--- a/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/RejectWithdrawal.tsx
+++ b/packages/nextjs/app/(routes)/cohort/[cohortAddress]/members/_components/RejectWithdrawal.tsx
@@ -1,18 +1,31 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useRejectWithdrawal } from "~~/hooks/useRejectWithdrawal";
 
 interface RejectWithdrawalProps {
   requestId: number;
   cohortAddress: string;
   builderAddress: string;
+  onClose: () => void;
 }
 
-export const RejectWithdrawal = ({ requestId, cohortAddress, builderAddress }: RejectWithdrawalProps) => {
-  const { rejectWithdrawal, isPending } = useRejectWithdrawal({
+export const RejectWithdrawal = ({ requestId, cohortAddress, builderAddress, onClose }: RejectWithdrawalProps) => {
+  const { rejectWithdrawal, isPending, isSuccess } = useRejectWithdrawal({
     cohortAddress,
     builderAddress,
     requestId,
   });
+
+  useEffect(() => {
+    if (isSuccess) {
+      const modalCheckbox = document.getElementById("withdraw-events-modal") as HTMLInputElement;
+      if (modalCheckbox) {
+        modalCheckbox.checked = false;
+        onClose();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess]);
+
   return (
     <button onClick={rejectWithdrawal} disabled={isPending} className="btn btn-sm rounded-md btn-warning">
       Reject

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -71,6 +71,10 @@ export const EtherInput = ({
   }, [nativeCurrencyPrice, transitoryDisplayValue, displayUsdMode, value]);
 
   const handleChangeNumber = (newValue: string) => {
+    if (newValue.startsWith(".")) {
+      newValue = "0" + newValue;
+    }
+
     if (newValue && !SIGNED_NUMBER_REGEX.test(newValue)) {
       return;
     }

--- a/packages/nextjs/hooks/useApproveWithdrawal.ts
+++ b/packages/nextjs/hooks/useApproveWithdrawal.ts
@@ -18,7 +18,7 @@ export const useApproveWithdrawal = ({ cohortAddress, builderAddress, requestId 
   const { targetNetwork } = useTargetNetwork();
   const cohort = contracts?.[baseChainId]["Cohort"];
   const writeTx = useTransactor();
-  const { isPending, writeContractAsync } = useWriteContract();
+  const { isPending, writeContractAsync, isSuccess } = useWriteContract();
 
   const sendContractWriteTx = async () => {
     if (!chain) {
@@ -54,5 +54,6 @@ export const useApproveWithdrawal = ({ cohortAddress, builderAddress, requestId 
   return {
     approveWithdrawal: sendContractWriteTx,
     isPending,
+    isSuccess,
   };
 };

--- a/packages/nextjs/hooks/useCompleteWithdrawal.ts
+++ b/packages/nextjs/hooks/useCompleteWithdrawal.ts
@@ -18,7 +18,7 @@ export const useCompleteWithdrawal = ({ cohortAddress, requestId }: useCompleteW
   const { targetNetwork } = useTargetNetwork();
   const cohort = contracts?.[baseChainId]["Cohort"];
   const writeTx = useTransactor();
-  const { isPending, writeContractAsync } = useWriteContract();
+  const { isPending, writeContractAsync, isSuccess } = useWriteContract();
 
   const sendContractWriteTx = async () => {
     if (!chain) {
@@ -54,5 +54,6 @@ export const useCompleteWithdrawal = ({ cohortAddress, requestId }: useCompleteW
   return {
     completeWithdrawal: sendContractWriteTx,
     isPending,
+    isSuccess,
   };
 };

--- a/packages/nextjs/hooks/useFunding.ts
+++ b/packages/nextjs/hooks/useFunding.ts
@@ -40,6 +40,8 @@ export const useFunding = ({
   const [tokenSymbol, setTokenSymbol] = useState<string>();
   const [tokenName, setTokenName] = useState<string>();
 
+  const [isSuccess, setIsSuccess] = useState(false);
+
   const [updateAllowance, setUpdateAllowance] = useState(false);
 
   const { isPending, writeContractAsync } = useWriteContract();
@@ -123,6 +125,7 @@ export const useFunding = ({
           });
 
         await writeTx(makeWriteWithParams);
+        setIsSuccess(true);
       } catch (e: any) {
         const message = getParsedError(e);
         notification.error(message);
@@ -230,5 +233,6 @@ export const useFunding = ({
     tokenName: tokenName,
     tokenDecimals: tokenDecimals,
     isLoading: isLoading || isPending,
+    isSuccess,
   };
 };

--- a/packages/nextjs/hooks/useRejectWithdrawal.ts
+++ b/packages/nextjs/hooks/useRejectWithdrawal.ts
@@ -18,7 +18,7 @@ export const useRejectWithdrawal = ({ cohortAddress, builderAddress, requestId }
   const { targetNetwork } = useTargetNetwork();
   const cohort = contracts?.[baseChainId]["Cohort"];
   const writeTx = useTransactor();
-  const { isPending, writeContractAsync } = useWriteContract();
+  const { isPending, writeContractAsync, isSuccess } = useWriteContract();
 
   const sendContractWriteTx = async () => {
     if (!chain) {
@@ -54,5 +54,6 @@ export const useRejectWithdrawal = ({ cohortAddress, builderAddress, requestId }
   return {
     rejectWithdrawal: sendContractWriteTx,
     isPending,
+    isSuccess,
   };
 };


### PR DESCRIPTION
Fixes to issue #43 and #44

- Modals now close for funding cohort, request withdawals , accept withdrawals, reject withdrawals  and complete withdrawals when the transaction is succesful
- Etherinputs now allows for inputs starting with a period