### PR TITLE
Remove BASE token

### DIFF
--- a/packages/nextjs/data/currencies.ts
+++ b/packages/nextjs/data/currencies.ts
@@ -114,10 +114,6 @@ export const currencies: CurrenciesType = {
         address: "0x0000000000000000000000000000000000000000",
       },
       {
-        name: "BASE",
-        address: "0xd07379a755a8f11b57610154861d694b2a0f615a",
-      },
-      {
         name: "USDC",
         address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
       },


### PR DESCRIPTION
Removes the option to stream BASE token on the Base chain, as Base doesn't have a native token.